### PR TITLE
feat: 2FA improvements, searchable bank select, run form draft persis…

### DIFF
--- a/app/dashboard/runs/new/page.tsx
+++ b/app/dashboard/runs/new/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { ArrowLeft, Download, MessageSquare, Plus, Rocket, Settings2, Trash2, Upload, X } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { Field, TextInput, TextareaInput, DateRangeInput, SelectInput, NumericInput, AmountInput } from "@/components/ui/form-fields";
+import { Field, TextInput, TextareaInput, DateRangeInput, BankSelectInput, NumericInput, AmountInput } from "@/components/ui/form-fields";
 import { naira } from "@/lib/mock-data";
 import { useInstitutions } from "@/hooks/use-institutions";
 import type { CreateRunPayload, Institution } from "@/lib/api-types";
@@ -93,6 +93,8 @@ export default function NewRunPage() {
   );
   const institutionsError = institutionsIsError ? "Unable to load institutions." : null;
 
+  const DRAFT_KEY = `run-form-draft-${businessId ?? "default"}`;
+
   const [objective, setObjective] = useState("");
   const [fromDate, setFromDate] = useState("");
   const [toDate, setToDate] = useState("");
@@ -102,9 +104,52 @@ export default function NewRunPage() {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [csvError, setCsvError] = useState<string | null>(null);
   const [recipients, setRecipients] = useState<Recipient[]>([emptyRow()]);
+  const [draftRestored, setDraftRestored] = useState(false);
   const csvRef = useRef<HTMLInputElement>(null);
 
-  const createRun = useCreateRun((runId) => router.push(`/dashboard/runs/${runId}`));
+  // Restore draft on mount
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(DRAFT_KEY);
+      if (!raw) return;
+      const draft = JSON.parse(raw);
+      if (draft.objective) setObjective(draft.objective);
+      if (draft.fromDate) setFromDate(draft.fromDate);
+      if (draft.toDate) setToDate(draft.toDate);
+      if (typeof draft.riskTolerance === "number") setRiskTolerance(draft.riskTolerance);
+      if (draft.budgetCap) setBudgetCap(draft.budgetCap);
+      if (Array.isArray(draft.recipients) && draft.recipients.length > 0) setRecipients(draft.recipients);
+      setDraftRestored(true);
+    } catch { /* ignore malformed */ }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Save draft whenever form changes
+  useEffect(() => {
+    const hasMeaningfulData =
+      objective || fromDate || toDate || budgetCap ||
+      recipients.some((r) => r.beneficiaryName || r.institutionCode || r.accountNumber || r.amount);
+    if (hasMeaningfulData) {
+      localStorage.setItem(DRAFT_KEY, JSON.stringify({ objective, fromDate, toDate, riskTolerance, budgetCap, recipients }));
+    }
+  }, [objective, fromDate, toDate, riskTolerance, budgetCap, recipients, DRAFT_KEY]);
+
+  const clearDraft = () => {
+    localStorage.removeItem(DRAFT_KEY);
+    setDraftRestored(false);
+    setObjective("");
+    setFromDate("");
+    setToDate("");
+    setRiskTolerance(0.35);
+    setBudgetCap("");
+    setRecipients([emptyRow()]);
+    setSubmitted(false);
+  };
+
+  const createRun = useCreateRun((runId) => {
+    localStorage.removeItem(DRAFT_KEY);
+    router.push(`/dashboard/runs/${runId}`);
+  });
   const confirmRun = useConfirmRun();
   const abandonConversation = useAbandonConversation();
 
@@ -457,6 +502,16 @@ export default function NewRunPage() {
         </div>
       </div>
 
+      {/* Draft restored banner */}
+      {draftRestored && (
+        <div className="flex items-center justify-between rounded-2xl border border-brand/30 bg-brand/5 px-4 py-3">
+          <p className="text-sm text-brand font-medium">Draft restored — continue from where you left off.</p>
+          <button type="button" onClick={clearDraft} className="text-xs font-semibold text-brand/70 hover:text-destructive transition-colors">
+            Clear draft
+          </button>
+        </div>
+      )}
+
       {/* Run Configuration */}
       <section className="space-y-5">
         <h2 className="text-xs font-black uppercase tracking-wider text-muted-foreground">Run Configuration</h2>
@@ -575,10 +630,10 @@ export default function NewRunPage() {
                   </Field>
 
                   <Field label="Bank / Institution" className="sm:col-span-2">
-                    <SelectInput
+                    <BankSelectInput
                       value={row.institutionCode}
                       onChange={(v) => updateRow(row.id, { institutionCode: v })}
-                      placeholder={loadingInstitutions ? "Loading banks…" : "Select bank"}
+                      placeholder={loadingInstitutions ? "Loading banks…" : "Search bank…"}
                       options={institutionOptions}
                     />
                   </Field>

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -10,6 +10,7 @@ import {
   ChevronDown,
   ChevronUp,
   Copy,
+  Download,
   KeyRound,
   Loader2,
   LogOut,
@@ -41,6 +42,7 @@ import {
   useUpdateOrgConfig,
   useExportAccountData,
   useDeleteAccount,
+  useRequestDeleteCode,
 } from "@/hooks/use-settings-queries";
 import { CardSelect, PillSelect, type CardSelectOption } from "@/components/ui/select-fields";
 import {
@@ -72,6 +74,7 @@ export default function SettingsPage() {
   const updateOrgConfigMut = useUpdateOrgConfig();
   const exportData = useExportAccountData();
   const deleteAccount = useDeleteAccount(() => logout());
+  const requestDeleteCode = useRequestDeleteCode();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Business configuration constants
@@ -121,7 +124,7 @@ export default function SettingsPage() {
   };
 
   const handleDisable2FA = async () => {
-    await twoFADisable.mutateAsync({ password: disablePw, code: disableCode });
+    await twoFADisable.mutateAsync(disablePw);
     setTwoFAStep("idle");
     setDisablePw("");
     setDisableCode("");
@@ -137,6 +140,21 @@ export default function SettingsPage() {
     navigator.clipboard.writeText(backupCodes.join("\n"));
     setBackupCopied(true);
     setTimeout(() => setBackupCopied(false), 2000);
+  };
+
+  const downloadBackupCodes = () => {
+    const content = [
+      "FlowPilot — 2FA Backup Codes",
+      "Keep these codes somewhere safe. Each code can only be used once.",
+      "",
+      ...backupCodes,
+    ].join("\n");
+    const url = URL.createObjectURL(new Blob([content], { type: "text/plain" }));
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "flowpilot-backup-codes.txt";
+    a.click();
+    URL.revokeObjectURL(url);
   };
 
   const is2FAEnabled = twoFAStatus.data?.totp_enabled ?? false;
@@ -157,6 +175,12 @@ export default function SettingsPage() {
   const [currentPw, setCurrentPw] = useState("");
   const [newPw, setNewPw] = useState("");
   const [confirmPw, setConfirmPw] = useState("");
+  const [changePwOtp, setChangePwOtp] = useState("");
+
+  // Delete account verification state
+  const [deleteOtp, setDeleteOtp] = useState("");
+  const [deleteEmailCode, setDeleteEmailCode] = useState("");
+  const [deleteCodeSent, setDeleteCodeSent] = useState(false);
 
   // Org edit state
   const [orgEditing, setOrgEditing] = useState(false);
@@ -178,6 +202,9 @@ export default function SettingsPage() {
 
   const org = orgQuery.data;
   const connections = connectionsQuery.data?.connections ?? [];
+
+  // org enforcement: use mutation result (most recent) or fall back to org profile data
+  const isOrgEnforced: boolean = orgRequire2FA.data?.require_2fa ?? (org?.config?.require_2fa ?? false);
 
   const initials = [user?.first_name?.[0], user?.last_name?.[0]]
     .filter(Boolean)
@@ -208,12 +235,13 @@ export default function SettingsPage() {
   const handlePasswordChange = () => {
     if (newPw !== confirmPw) return;
     changePasswordMut.mutate(
-      { current: currentPw, next: newPw },
+      { current: currentPw, next: newPw, totpCode: is2FAEnabled ? changePwOtp : undefined },
       {
         onSuccess: () => {
           setCurrentPw("");
           setNewPw("");
           setConfirmPw("");
+          setChangePwOtp("");
         },
       }
     );
@@ -593,8 +621,17 @@ export default function SettingsPage() {
                   {newPw && confirmPw && newPw !== confirmPw && (
                     <p className="text-xs text-destructive">Passwords do not match</p>
                   )}
+                  {is2FAEnabled && (
+                    <div className="space-y-1.5 rounded-xl border border-border/60 bg-muted/40 p-3">
+                      <p className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
+                        <ShieldCheck className="h-3.5 w-3.5 text-brand" />
+                        Enter your authenticator code to confirm
+                      </p>
+                      <OtpInput length={6} value={changePwOtp} onChange={setChangePwOtp} />
+                    </div>
+                  )}
                   <div>
-                    <Button className="mt-2 rounded-full px-6 shadow-sm" onClick={handlePasswordChange} disabled={changePasswordMut.isPending || !currentPw || !newPw || newPw !== confirmPw}>
+                    <Button className="mt-2 rounded-full px-6 shadow-sm" onClick={handlePasswordChange} disabled={changePasswordMut.isPending || !currentPw || !newPw || newPw !== confirmPw || (is2FAEnabled && changePwOtp.length < 6)}>
                       {changePasswordMut.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
                       Update Password
                     </Button>
@@ -672,6 +709,9 @@ export default function SettingsPage() {
                       <Button variant="outline" className="rounded-full shadow-sm" onClick={copyBackupCodes}>
                         {backupCopied ? <><CheckCircle2 className="mr-2 h-4 w-4 text-brand" />Copied!</> : <><Copy className="mr-2 h-4 w-4" />Copy All</>}
                       </Button>
+                      <Button variant="outline" className="rounded-full shadow-sm" onClick={downloadBackupCodes}>
+                        <Download className="mr-2 h-4 w-4" />Download
+                      </Button>
                       <Button className="rounded-full bg-brand px-6 text-white shadow-sm hover:opacity-90" onClick={() => setTwoFAStep("idle")}>Done</Button>
                     </div>
                   </div>
@@ -698,17 +738,13 @@ export default function SettingsPage() {
                   <div className="space-y-4 rounded-2xl border border-destructive/20 bg-destructive/5 p-5 shadow-sm">
                     <div className="flex items-center gap-2">
                       <KeyRound className="h-4 w-4 text-destructive" />
-                      <p className="text-sm font-semibold text-foreground">Confirm your identity to disable 2FA</p>
+                      <p className="text-sm font-semibold text-foreground">Enter your password to disable 2FA</p>
                     </div>
-                    <div className="grid gap-3 sm:max-w-sm">
+                    <div className="sm:max-w-sm">
                       <Input type="password" placeholder="Your account password" className="h-10 rounded-xl" value={disablePw} onChange={(e) => setDisablePw(e.target.value)} />
-                      <div className="space-y-1.5">
-                        <p className="text-xs text-muted-foreground">Current authenticator code</p>
-                        <OtpInput length={6} value={disableCode} onChange={setDisableCode} />
-                      </div>
                     </div>
                     <div className="flex gap-3">
-                      <Button variant="destructive" className="rounded-full shadow-sm" onClick={handleDisable2FA} disabled={twoFADisable.isPending || !disablePw || disableCode.length < 6}>
+                      <Button variant="destructive" className="rounded-full shadow-sm" onClick={handleDisable2FA} disabled={twoFADisable.isPending || !disablePw}>
                         {twoFADisable.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
                         Disable 2FA
                       </Button>
@@ -720,23 +756,34 @@ export default function SettingsPage() {
                 {isOwner && (
                   <div className="border-t border-border/50 pt-4 space-y-3">
                     <button type="button" className="flex w-full items-center justify-between text-sm font-semibold text-foreground" onClick={() => setShowOrgEnforce((p) => !p)}>
-                      <span>Organisation-wide 2FA Enforcement</span>
+                      <div className="flex items-center gap-2">
+                        <span>Organisation-wide 2FA Enforcement</span>
+                        {isOrgEnforced && (
+                          <span className="inline-flex items-center gap-1 rounded-full bg-brand/10 px-2 py-0.5 text-xs font-semibold text-brand">
+                            <CheckCircle2 className="h-3 w-3" />Enforced
+                          </span>
+                        )}
+                      </div>
                       {showOrgEnforce ? <ChevronUp className="h-4 w-4 text-muted-foreground" /> : <ChevronDown className="h-4 w-4 text-muted-foreground" />}
                     </button>
                     {showOrgEnforce && (
                       <div className="rounded-2xl border border-border/60 bg-card p-4 space-y-3 shadow-sm">
                         <p className="text-sm text-muted-foreground">
-                          Require all team members to enable 2FA. Members without 2FA will have a 24-hour grace period before access is restricted.
+                          {isOrgEnforced
+                            ? "2FA is currently enforced for all team members. Members without 2FA are given a 24-hour grace period before access is restricted."
+                            : "Require all team members to enable 2FA. Members without 2FA will have a 24-hour grace period before access is restricted."}
                         </p>
-                        <div className="flex gap-3">
-                          <Button className="rounded-full bg-brand px-6 text-white shadow-sm hover:opacity-90" onClick={() => orgRequire2FA.mutate(true)} disabled={orgRequire2FA.isPending}>
-                            {orgRequire2FA.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-                            Enforce 2FA for Team
-                          </Button>
-                          <Button variant="outline" className="rounded-full shadow-sm" onClick={() => orgRequire2FA.mutate(false)} disabled={orgRequire2FA.isPending}>
+                        {isOrgEnforced ? (
+                          <Button variant="outline" className="rounded-full shadow-sm border-destructive/30 text-destructive hover:bg-destructive/10" onClick={() => orgRequire2FA.mutate(false)} disabled={orgRequire2FA.isPending}>
+                            {orgRequire2FA.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <ShieldOff className="mr-2 h-4 w-4" />}
                             Remove Enforcement
                           </Button>
-                        </div>
+                        ) : (
+                          <Button className="rounded-full bg-brand px-6 text-white shadow-sm hover:opacity-90" onClick={() => orgRequire2FA.mutate(true)} disabled={orgRequire2FA.isPending}>
+                            {orgRequire2FA.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <ShieldCheck className="mr-2 h-4 w-4" />}
+                            Enforce 2FA for Team
+                          </Button>
+                        )}
                       </div>
                     )}
                   </div>
@@ -779,7 +826,7 @@ export default function SettingsPage() {
                     <p className="font-bold text-destructive">Delete Account</p>
                     <p className="mt-0.5 text-sm text-destructive/80">Permanently deactivates your account and entire workspace. This cannot be undone.</p>
                   </div>
-                  <Button variant="destructive" className="shrink-0 rounded-full shadow-sm" onClick={() => { setDeleteOpen(true); setDeleteConfirmText(""); }}>
+                  <Button variant="destructive" className="shrink-0 rounded-full shadow-sm" onClick={() => { setDeleteOpen(true); setDeleteConfirmText(""); setDeleteOtp(""); setDeleteEmailCode(""); setDeleteCodeSent(false); }}>
                     <Trash2 className="mr-2 h-4 w-4" /> Delete Account
                   </Button>
                 </div>
@@ -817,10 +864,53 @@ export default function SettingsPage() {
                 </label>
                 <Input value={deleteConfirmText} onChange={(e) => setDeleteConfirmText(e.target.value)} placeholder="DELETE" className="h-10 rounded-xl font-mono" autoComplete="off" />
               </div>
+
+              {/* ── Verification ── */}
+              {is2FAEnabled ? (
+                <div className="space-y-1.5 rounded-xl border border-border/60 bg-muted/40 p-3">
+                  <p className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
+                    <ShieldCheck className="h-3.5 w-3.5 text-brand" />
+                    Enter your authenticator code
+                  </p>
+                  <OtpInput length={6} value={deleteOtp} onChange={setDeleteOtp} />
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
+                    <KeyRound className="h-3.5 w-3.5" />
+                    Verify your identity via email code
+                  </p>
+                  {!deleteCodeSent ? (
+                    <Button variant="outline" className="rounded-full shadow-sm w-full" onClick={() => requestDeleteCode.mutate(undefined, { onSuccess: () => setDeleteCodeSent(true) })} disabled={requestDeleteCode.isPending}>
+                      {requestDeleteCode.isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                      Send Verification Code
+                    </Button>
+                  ) : (
+                    <div className="space-y-1.5">
+                      <p className="text-xs text-muted-foreground">Enter the 6-digit code sent to your email</p>
+                      <OtpInput length={6} value={deleteEmailCode} onChange={setDeleteEmailCode} />
+                      <button type="button" className="text-xs text-brand underline-offset-2 hover:underline" onClick={() => requestDeleteCode.mutate(undefined, { onSuccess: () => setDeleteCodeSent(true) })} disabled={requestDeleteCode.isPending}>
+                        Resend code
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
             <div className="flex items-center justify-end gap-3 border-t border-border px-6 py-4">
               <Button variant="ghost" className="rounded-full px-6" onClick={() => setDeleteOpen(false)} disabled={deleteAccount.isPending}>Cancel</Button>
-              <Button variant="destructive" className="rounded-full px-6 shadow-sm" disabled={deleteConfirmText !== "DELETE" || deleteAccount.isPending} onClick={() => deleteAccount.mutate()}>
+              <Button
+                variant="destructive"
+                className="rounded-full px-6 shadow-sm"
+                disabled={
+                  deleteConfirmText !== "DELETE" ||
+                  deleteAccount.isPending ||
+                  (is2FAEnabled ? deleteOtp.length < 6 : !deleteCodeSent || deleteEmailCode.length < 6)
+                }
+                onClick={() => deleteAccount.mutate(
+                  is2FAEnabled ? { totp_code: deleteOtp } : { delete_code: deleteEmailCode }
+                )}
+              >
                 {deleteAccount.isPending ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Deleting…</> : <><Trash2 className="mr-2 h-4 w-4" />Delete Everything</>}
               </Button>
             </div>

--- a/components/ui/form-fields.tsx
+++ b/components/ui/form-fields.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { ArrowRight, Calendar, Eye, EyeOff, Search } from "lucide-react";
+import { ArrowRight, Calendar, ChevronDown, Eye, EyeOff, Search, X } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
@@ -109,6 +109,133 @@ export function SelectInput({
           <path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" />
         </svg>
       </div>
+    </div>
+  );
+}
+
+/**
+ * BankSelectInput: Searchable combobox for institution/bank selection
+ */
+export function BankSelectInput({
+  value,
+  onChange,
+  placeholder = "Search bank…",
+  options,
+  className,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  options: SelectOption[];
+  className?: string;
+}) {
+  const normalized = options.map((o) =>
+    typeof o === "string" ? { label: o, value: o } : o
+  );
+
+  const selectedLabel = normalized.find((o) => o.value === value)?.label ?? "";
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = query.trim()
+    ? normalized.filter(
+        (o) =>
+          o.label.toLowerCase().includes(query.toLowerCase()) ||
+          o.value.toLowerCase().includes(query.toLowerCase())
+      )
+    : normalized;
+
+  // Close on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setQuery("");
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  const handleInputFocus = () => {
+    setOpen(true);
+    setQuery("");
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
+    setOpen(true);
+    if (!e.target.value) onChange("");
+  };
+
+  const handleSelect = (val: string) => {
+    onChange(val);
+    setOpen(false);
+    setQuery("");
+    inputRef.current?.blur();
+  };
+
+  const handleClear = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onChange("");
+    setQuery("");
+    setOpen(false);
+  };
+
+  return (
+    <div ref={containerRef} className={cn("relative", className)}>
+      <div
+        className={cn(
+          "flex h-12 items-center gap-2 rounded-full border border-border bg-background px-4 transition-all",
+          "focus-within:border-brand focus-within:ring-1 focus-within:ring-brand/10",
+          open && "border-brand ring-1 ring-brand/10"
+        )}
+        onClick={() => inputRef.current?.focus()}
+      >
+        <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <input
+          ref={inputRef}
+          value={open ? query : selectedLabel}
+          onChange={handleInputChange}
+          onFocus={handleInputFocus}
+          placeholder={value ? selectedLabel : placeholder}
+          className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+        />
+        {value ? (
+          <button type="button" onClick={handleClear} className="shrink-0 text-muted-foreground hover:text-foreground transition-colors">
+            <X className="h-3.5 w-3.5" />
+          </button>
+        ) : (
+          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+        )}
+      </div>
+
+      {open && (
+        <div className="absolute left-0 right-0 top-full z-50 mt-1.5 max-h-56 overflow-y-auto rounded-2xl border border-border bg-card shadow-lg">
+          {filtered.length === 0 ? (
+            <div className="px-4 py-3 text-sm text-muted-foreground">
+              No banks found{query ? ` for "${query}"` : ""}
+            </div>
+          ) : (
+            filtered.map((o) => (
+              <button
+                key={o.value}
+                type="button"
+                onMouseDown={(e) => e.preventDefault()} // prevent blur before click
+                onClick={() => handleSelect(o.value)}
+                className={cn(
+                  "w-full px-4 py-2.5 text-left text-sm transition-colors hover:bg-muted/60",
+                  value === o.value && "bg-brand/10 font-semibold text-brand"
+                )}
+              >
+                {o.label}
+              </button>
+            ))
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/hooks/use-2fa-queries.ts
+++ b/hooks/use-2fa-queries.ts
@@ -45,8 +45,7 @@ export function use2FAEnable() {
 export function use2FADisable() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ password, code }: { password: string; code: string }) =>
-      disable2FA(password, code),
+    mutationFn: (password: string) => disable2FA(password),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["2fa-status"] });
       qc.invalidateQueries({ queryKey: ["auth-user"] });
@@ -73,9 +72,11 @@ export function useRegenerateBackupCodes() {
 }
 
 export function useSetOrgRequire2FA() {
+  const qc = useQueryClient();
   return useMutation({
     mutationFn: (require: boolean) => setOrgRequire2FA(require),
     onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ["org-profile"] });
       toast.success(
         data.require_2fa
           ? "2FA enforcement enabled for all team members"

--- a/hooks/use-settings-queries.ts
+++ b/hooks/use-settings-queries.ts
@@ -9,6 +9,7 @@ import {
   getConnections,
   getOrgProfile,
   removeAvatar,
+  requestDeleteCode,
   updateMe,
   updateOrgConfig,
   updateOrgProfile,
@@ -76,11 +77,21 @@ export function useRemoveAvatar() {
 
 export function useChangePassword() {
   return useMutation({
-    mutationFn: ({ current, next }: { current: string; next: string }) =>
-      changePassword(current, next),
+    mutationFn: ({ current, next, totpCode }: { current: string; next: string; totpCode?: string }) =>
+      changePassword(current, next, totpCode),
     onSuccess: () => toast.success("Password updated successfully"),
     onError: (err) => {
       toast.error(err instanceof Error ? err.message : "Failed to change password");
+    },
+  });
+}
+
+export function useRequestDeleteCode() {
+  return useMutation({
+    mutationFn: () => requestDeleteCode(),
+    onSuccess: () => toast.success("Verification code sent to your email"),
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : "Failed to send verification code");
     },
   });
 }
@@ -133,7 +144,7 @@ export function useExportAccountData() {
 
 export function useDeleteAccount(onDeleted: () => void) {
   return useMutation({
-    mutationFn: () => deleteAccount(),
+    mutationFn: (params?: { totp_code?: string; delete_code?: string }) => deleteAccount(params),
     onSuccess: () => {
       toast.success("Account deleted. Signing you out…");
       onDeleted();

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -410,11 +410,12 @@ export function acceptInviteToken(
     .then((r) => r.data);
 }
 
-export function changePassword(currentPassword: string, newPassword: string): Promise<{ message: string }> {
+export function changePassword(currentPassword: string, newPassword: string, totpCode?: string): Promise<{ message: string }> {
   return apiClient
     .post<{ message: string }>("/auth/me/password", {
       current_password: currentPassword,
       new_password: newPassword,
+      ...(totpCode ? { totp_code: totpCode } : {}),
     })
     .then((r) => r.data);
 }
@@ -443,9 +444,13 @@ export function exportAccountData(): Promise<Blob> {
     .then((r) => r.data as Blob);
 }
 
-export function deleteAccount(): Promise<{ status: string; message: string }> {
+export function requestDeleteCode(): Promise<{ message: string }> {
+  return apiClient.post<{ message: string }>("/account/request-delete-code").then((r) => r.data);
+}
+
+export function deleteAccount(params?: { totp_code?: string; delete_code?: string }): Promise<{ status: string; message: string }> {
   return apiClient
-    .delete<{ status: string; message: string }>("/account/delete")
+    .delete<{ status: string; message: string }>("/account/delete", { data: params ?? {} })
     .then((r) => r.data);
 }
 
@@ -464,8 +469,8 @@ export function enable2FA(code: string): Promise<{ backup_codes: string[] }> {
   return apiClient.post<{ backup_codes: string[] }>("/auth/2fa/enable", { code }).then((r) => r.data);
 }
 
-export function disable2FA(password: string, code: string): Promise<{ message: string }> {
-  return apiClient.post<{ message: string }>("/auth/2fa/disable", { password, code }).then((r) => r.data);
+export function disable2FA(password: string): Promise<{ message: string }> {
+  return apiClient.post<{ message: string }>("/auth/2fa/disable", { password }).then((r) => r.data);
 }
 
 export function verifyMfa(mfa_token: string, code: string): Promise<AuthResponse> {

--- a/lib/api-types.ts
+++ b/lib/api-types.ts
@@ -475,6 +475,7 @@ export interface OrgConfig {
   risk_alert_threshold: number | null;
   liquidity_alert_buffer: number | null;
   preferences: Record<string, unknown> | null;
+  require_2fa: boolean;
 }
 
 // ── Connections ──────────────────────────────────────────────


### PR DESCRIPTION
…tence, account deletion verification

- 2FA disable: password-only (remove TOTP requirement), add 2fa_disabled email template
- Add Download button for backup codes alongside Copy All
- Enforce org-wide 2FA button reflects current state with Enforced badge
- Password change: require TOTP code when 2FA is enabled
- Account deletion: require TOTP (if 2FA) or email verification code (if not)
- Bank/institution selector: replace plain select with searchable combobox (BankSelectInput)
- Run form draft: auto-save to localStorage, restore on page load with Clear draft option
- Add require_2fa to OrgConfig type