### PR TITLE
fix: invalidate notifications cache on run creation and update docs e…

### DIFF
--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1060,7 +1060,7 @@ async def handle_webhook(request: Request):
                   href="mailto:dev@flowpilot.club"
                   className="text-[#64748b] hover:text-[#e86727] transition-colors"
                 >
-                  dev@flowpilot.ng
+                  dev@flowpilot.club
                 </a>
               </p>
             </div>

--- a/hooks/use-run-mutations.ts
+++ b/hooks/use-run-mutations.ts
@@ -12,6 +12,7 @@ export function useCreateRun(onSuccess: (runId: string) => void) {
     mutationFn: (payload: CreateRunPayload) => createRun(payload),
     onSuccess: (run) => {
       queryClient.invalidateQueries({ queryKey: ["runs"] });
+      queryClient.invalidateQueries({ queryKey: ["notifications"] });
       onSuccess(run.run_id);
     },
     onError: (err) => {


### PR DESCRIPTION
…mail

- Invalidate ["notifications"] query after run creation so the bell badge and notifications page refresh immediately with the new run notifications
- Update docs contact email from flowpilot.ng to flowpilot.club