### PR TITLE
feat: rename run→payout in UI, sidebar Payouts group, standalone Temp…

### DIFF
--- a/app/dashboard/approvals/page.tsx
+++ b/app/dashboard/approvals/page.tsx
@@ -51,7 +51,7 @@ export default function ApprovalsPage() {
     <div className="space-y-6">
       <PageHeader
         title="Approvals"
-        description="Review and approve pending disbursements across all runs."
+        description="Review and approve pending disbursements across all payouts."
       />
 
       <div className="grid gap-4 sm:grid-cols-3">
@@ -108,7 +108,7 @@ export default function ApprovalsPage() {
           <table className="min-w-full text-sm">
             <thead>
               <tr className="border-b border-border text-left">
-                {["Beneficiary", "Amount", "Risk Score", "Risk Decision", "Status", "Run", "Created"].map((h) => (
+                {["Beneficiary", "Amount", "Risk Score", "Risk Decision", "Status", "Payout", "Created"].map((h) => (
                   <th key={h} className="px-6 py-3 text-xs font-black uppercase tracking-wider text-muted-foreground">
                     {h}
                   </th>

--- a/app/dashboard/audit/page.tsx
+++ b/app/dashboard/audit/page.tsx
@@ -74,7 +74,7 @@ export default function AuditPage() {
     <div className="space-y-6">
       <PageHeader
         title="Audit Trail"
-        description="Full audit trail and agent activity across all runs."
+        description="Full audit trail and agent activity across all payouts."
       />
 
       <div className="grid gap-4 sm:grid-cols-3">
@@ -86,7 +86,7 @@ export default function AuditPage() {
           accent="brand"
         />
         <MetricCard
-          label="Runs Covered"
+          label="Payouts Covered"
           value={isLoading ? "…" : String(uniqueRuns)}
           subtext="Distinct runs"
           icon={<Activity className="h-4 w-4" />}
@@ -154,7 +154,7 @@ export default function AuditPage() {
                         : "text-muted-foreground hover:text-foreground"
                     }`}
                   >
-                    {tab === "action" ? "Action" : "Run ID"}
+                    {tab === "action" ? "Action" : "Payout ID"}
                   </button>
                 ))}
               </div>
@@ -176,7 +176,7 @@ export default function AuditPage() {
                     key="run_id"
                     value={runIdFilter}
                     onChange={(e) => { setRunIdFilter(e.target.value); setOffset(0); }}
-                    placeholder="Run ID…"
+                    placeholder="Payout ID…"
                     className="w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
                   />
                 )}

--- a/app/dashboard/conversations/page.tsx
+++ b/app/dashboard/conversations/page.tsx
@@ -330,7 +330,7 @@ export default function ConversationsPage() {
           <div>
             <p className="text-base font-black text-foreground">No conversations yet</p>
             <p className="mt-1 text-sm text-muted-foreground max-w-xs">
-              Start a new payout run and chat with FlowPilot — your conversation history will appear here.
+              Start a new payout and chat with FlowPilot — your conversation history will appear here.
             </p>
           </div>
           <Button

--- a/app/dashboard/kyc/page.tsx
+++ b/app/dashboard/kyc/page.tsx
@@ -180,7 +180,7 @@ export default function KycPage() {
           <div className="rounded-2xl border border-blue-200 bg-blue-50 p-5 flex items-start gap-3">
             <AlertCircle className="h-5 w-5 text-blue-500 shrink-0 mt-0.5" />
             <p className="text-sm text-blue-800">
-              To create payout runs, we need to verify your business identity.
+              To create payouts, we need to verify your business identity.
               Upload the required documents below. Review typically completes within 10 minutes.
             </p>
           </div>

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -204,7 +204,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
               <span className={`inline-block h-1.5 w-1.5 rounded-full animate-pulse ${kycStatus === "pending" ? "bg-amber-500" : "bg-[#e86727]"}`} />
               {kycStatus === "pending"
                 ? "Your documents are under review — you'll be notified within 10 minutes."
-                : "Complete your business verification (KYC) to unlock payout runs."}
+                : "Complete your business verification (KYC) to unlock payouts."}
               <Link href="/dashboard/kyc" className="underline font-semibold ml-1">
                 {kycStatus === "pending" ? "View status" : "Verify now"}
               </Link>

--- a/app/dashboard/notifications/page.tsx
+++ b/app/dashboard/notifications/page.tsx
@@ -52,7 +52,7 @@ export default function NotificationsPage() {
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <PageHeader
           title="Notifications"
-          description="Stay updated on run completions, approvals, and system events."
+          description="Stay updated on payout completions, approvals, and system events."
         />
         {unreadCount > 0 && (
           <button

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -77,7 +77,7 @@ export default function DashboardPage() {
             className="h-10 shrink-0 rounded-full bg-primary px-5 text-primary-foreground font-semibold shadow-sm hover:opacity-90"
           >
             <Plus className="mr-1.5 h-4 w-4" />
-            Start New Run
+            New Payout
           </Button>
         )}
       </div>
@@ -90,7 +90,7 @@ export default function DashboardPage() {
               <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-brand opacity-75" />
               <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-brand" />
             </span>
-            <span className="text-sm font-bold text-brand">Live Now — {liveRuns.length} run{liveRuns.length > 1 ? "s" : ""} processing</span>
+            <span className="text-sm font-bold text-brand">Live Now — {liveRuns.length} payout{liveRuns.length > 1 ? "s" : ""} processing</span>
           </div>
           <div className="flex flex-wrap gap-2">
             {liveRuns.map((run) => (
@@ -118,7 +118,7 @@ export default function DashboardPage() {
           accent="brand"
         />
         <MetricCard
-          label="Runs This Month"
+          label="Payouts This Month"
           value={isLoading ? "…" : String(stats?.runs_this_month ?? 0)}
           subtext="Since start of month"
           icon={<Zap className="h-4 w-4" />}
@@ -134,7 +134,7 @@ export default function DashboardPage() {
         <MetricCard
           label="Active Now"
           value={isLoading ? "…" : String(stats?.active_runs ?? 0)}
-          subtext="Runs currently processing"
+          subtext="Payouts currently processing"
           icon={<Activity className="h-4 w-4" />}
           accent={stats?.active_runs ? "brand" : "default"}
         />
@@ -148,7 +148,7 @@ export default function DashboardPage() {
 
       {/* ── Recent runs ──────────────────────────────────────────────────── */}
       <div>
-        <SectionHeader title="Recent Runs">
+        <SectionHeader title="Recent Payouts">
           <Link
             href="/dashboard/runs"
             className="flex items-center gap-1 text-xs font-semibold text-brand hover:opacity-80 transition-opacity"
@@ -167,9 +167,9 @@ export default function DashboardPage() {
               <Zap className="h-7 w-7" />
             </div>
             <div>
-              <p className="text-base font-black text-foreground">No runs yet</p>
+              <p className="text-base font-black text-foreground">No payouts yet</p>
               <p className="mt-1 text-sm text-muted-foreground max-w-xs">
-                Start your first payout run by telling FlowPilot what you need in plain language.
+                Start your first payout by telling FlowPilot what you need in plain language.
               </p>
             </div>
             {canRun && (
@@ -178,7 +178,7 @@ export default function DashboardPage() {
                 className="rounded-full bg-primary px-5 text-primary-foreground font-semibold hover:opacity-90"
               >
                 <Plus className="mr-1.5 h-4 w-4" />
-                Start your first run
+                Start your first payout
               </Button>
             )}
           </div>
@@ -261,7 +261,7 @@ export default function DashboardPage() {
             <QuickAction
               href="/dashboard/runs/new"
               icon={<Zap className="h-5 w-5" />}
-              title="Start a Payout Run"
+              title="Start a Payout"
               description="Describe your disbursement in plain English and let FlowPilot handle the rest."
               accent="brand"
             />

--- a/app/dashboard/runs/[id]/approve/page.tsx
+++ b/app/dashboard/runs/[id]/approve/page.tsx
@@ -10,6 +10,7 @@ import {
   ChevronDown,
   ChevronUp,
   Loader2,
+  Pencil,
   ShieldCheck,
   X,
 } from "lucide-react";
@@ -17,7 +18,7 @@ import { Button } from "@/components/ui/button";
 import { StatusBadge } from "@/components/status-badge";
 import { maskAccount, naira, truncateRunId } from "@/lib/mock-data";
 import { useCandidates } from "@/hooks/use-candidate-queries";
-import { useApproveCandidates } from "@/hooks/use-candidate-mutations";
+import { useApproveCandidates, useUpdateCandidate } from "@/hooks/use-candidate-mutations";
 import { useRun } from "@/hooks/use-run-queries";
 import { useAuth } from "@/context/auth-context";
 import { cn } from "@/lib/utils";
@@ -27,13 +28,7 @@ export default function ApprovalGatePage() {
   const router = useRouter();
   const { user } = useAuth();
   const role = user?.memberships?.[0]?.role;
-
-  // Analysts cannot approve — redirect to the run detail page
-  useEffect(() => {
-    if (user && role === "analyst") {
-      router.replace(`/dashboard/runs/${id}`);
-    }
-  }, [user, role, id, router]);
+  const userId = user?.id;
 
   const [query, setQuery] = useState("");
   const [selectedIds, setSelectedIds] = useState<string[] | null>(null);
@@ -43,6 +38,12 @@ export default function ApprovalGatePage() {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [confirmChecked, setConfirmChecked] = useState(false);
   const [expandedRisk, setExpandedRisk] = useState<string | null>(null);
+
+  // Inline edit state
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editAmount, setEditAmount] = useState("");
+  const [editName, setEditName] = useState("");
+  const [editAccount, setEditAccount] = useState("");
 
   const {
     data: allCandidates = [],
@@ -54,6 +55,21 @@ export default function ApprovalGatePage() {
   const approveMutation = useApproveCandidates(id, () => {
     router.push(`/dashboard/runs/${id}?phase=executing`);
   });
+
+  const updateMutation = useUpdateCandidate(id, () => setEditingId(null));
+
+  // Authorization: analysts cannot approve; non-assigned users cannot approve
+  useEffect(() => {
+    if (!user || !run) return;
+    if (role === "analyst") {
+      router.replace(`/dashboard/runs/${id}`);
+      return;
+    }
+    // If a specific approver is assigned and the current user is not them (and not an owner), redirect
+    if (run.assignedToId && run.assignedToId !== userId && role !== "owner") {
+      router.replace(`/dashboard/runs/${id}`);
+    }
+  }, [user, run, role, userId, id, router]);
 
   const effectiveSelectedIds =
     selectedIds ?? allCandidates.filter((c) => c.approvalStatus === "selected").map((c) => c.id);
@@ -70,9 +86,35 @@ export default function ApprovalGatePage() {
 
   const selectedCandidates = allCandidates.filter((candidate) => effectiveSelectedIds.includes(candidate.id));
   const selectedTotal = selectedCandidates.reduce((acc, candidate) => acc + candidate.amount, 0);
-  
+  const allCandidatesTotal = allCandidates.reduce((acc, c) => acc + c.amount, 0);
+  const budgetCap = run?.budgetCap ?? null;
+  const overBudget = budgetCap !== null && selectedTotal > budgetCap;
+
   const riskTolerance = run?.riskTolerance ?? 0.35;
   const reviewThreshold = riskTolerance + (1 - riskTolerance) / 2;
+
+  const startEdit = (candidateId: string) => {
+    const c = allCandidates.find((x) => x.id === candidateId);
+    if (!c) return;
+    setEditAmount(c.amount.toString());
+    setEditName(c.beneficiaryName);
+    setEditAccount(c.accountNumber);
+    setEditingId(candidateId);
+  };
+
+  const commitEdit = () => {
+    if (!editingId) return;
+    const amount = parseFloat(editAmount.replace(/,/g, ""));
+    if (isNaN(amount) || amount <= 0) return;
+    updateMutation.mutate({
+      candidateId: editingId,
+      payload: {
+        amount,
+        beneficiary_name: editName.trim() || undefined,
+        account_number: editAccount.trim() || undefined,
+      },
+    });
+  };
 
   const activeCandidate = allCandidates.find((candidate) => candidate.id === activeCandidateId) ?? null;
 
@@ -135,8 +177,28 @@ export default function ApprovalGatePage() {
         <span className="rounded-full bg-muted px-3 py-1 text-sm font-semibold text-foreground">
           Risk Tolerance {riskTolerance.toFixed(2)}
         </span>
+        {budgetCap !== null && (
+          <span className={cn(
+            "rounded-full px-3 py-1 text-sm font-semibold",
+            overBudget
+              ? "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
+              : "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400",
+          )}>
+            Budget: {naira(selectedTotal)} / {naira(budgetCap)}
+          </span>
+        )}
         <StatusBadge status="review" label="Forecast: Caution" />
       </div>
+
+      {/* ── Budget cap warning ── */}
+      {overBudget && (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-900 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            Selected total ({naira(selectedTotal)}) exceeds the run budget cap ({naira(budgetCap!)}). Deselect candidates or edit amounts before approving.
+          </div>
+        </div>
+      )}
 
       {/* ── Liquidity warning ── */}
       <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300">
@@ -181,6 +243,7 @@ export default function ApprovalGatePage() {
               <th className="px-4 py-3 text-[10px] font-black uppercase tracking-wider text-muted-foreground">Decision</th>
               <th className="px-4 py-3 text-[10px] font-black uppercase tracking-wider text-muted-foreground">Lookup</th>
               <th className="px-4 py-3 text-[10px] font-black uppercase tracking-wider text-muted-foreground">Risk Flags</th>
+              <th className="px-4 py-3 text-[10px] font-black uppercase tracking-wider text-muted-foreground">Edit</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
@@ -270,6 +333,60 @@ export default function ApprovalGatePage() {
                       </div>
                     ) : (
                       <span className="text-xs text-muted-foreground">—</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    {editingId === candidate.id ? (
+                      <div className="flex flex-col gap-1.5 min-w-[220px]">
+                        <input
+                          type="number"
+                          step="0.01"
+                          value={editAmount}
+                          onChange={(e) => setEditAmount(e.target.value)}
+                          placeholder="Amount"
+                          className="h-8 rounded-lg border border-border bg-background px-2 text-sm outline-none focus:border-brand"
+                        />
+                        <input
+                          type="text"
+                          value={editName}
+                          onChange={(e) => setEditName(e.target.value)}
+                          placeholder="Beneficiary name"
+                          className="h-8 rounded-lg border border-border bg-background px-2 text-sm outline-none focus:border-brand"
+                        />
+                        <input
+                          type="text"
+                          value={editAccount}
+                          onChange={(e) => setEditAccount(e.target.value)}
+                          placeholder="Account number"
+                          className="h-8 rounded-lg border border-border bg-background px-2 text-sm outline-none focus:border-brand"
+                        />
+                        <div className="flex gap-1">
+                          <button
+                            type="button"
+                            onClick={commitEdit}
+                            disabled={updateMutation.isPending}
+                            className="flex-1 rounded-lg bg-emerald-600 py-1 text-xs font-bold text-white hover:bg-emerald-700 disabled:opacity-60"
+                          >
+                            {updateMutation.isPending ? "…" : "Save"}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setEditingId(null)}
+                            className="flex-1 rounded-lg border border-border py-1 text-xs font-medium text-muted-foreground hover:text-foreground"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => startEdit(candidate.id)}
+                        className="inline-flex h-7 w-7 items-center justify-center rounded-lg border border-border text-muted-foreground hover:border-brand hover:text-brand transition-colors"
+                        title="Edit candidate"
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </button>
                     )}
                   </td>
                 </tr>
@@ -366,6 +483,50 @@ export default function ApprovalGatePage() {
                   )}
                 </div>
               )}
+
+              {/* Mobile inline edit */}
+              {editingId === candidate.id ? (
+                <div className="mt-3 space-y-2 rounded-xl border border-border bg-muted/30 p-3">
+                  <p className="text-xs font-black uppercase tracking-wider text-muted-foreground">Edit Details</p>
+                  <input
+                    type="number"
+                    step="0.01"
+                    value={editAmount}
+                    onChange={(e) => setEditAmount(e.target.value)}
+                    placeholder="Amount"
+                    className="h-9 w-full rounded-lg border border-border bg-background px-2 text-sm outline-none focus:border-brand"
+                  />
+                  <input
+                    type="text"
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    placeholder="Beneficiary name"
+                    className="h-9 w-full rounded-lg border border-border bg-background px-2 text-sm outline-none focus:border-brand"
+                  />
+                  <input
+                    type="text"
+                    value={editAccount}
+                    onChange={(e) => setEditAccount(e.target.value)}
+                    placeholder="Account number"
+                    className="h-9 w-full rounded-lg border border-border bg-background px-2 text-sm outline-none focus:border-brand"
+                  />
+                  <div className="flex gap-2">
+                    <Button size="sm" className="flex-1 rounded-full bg-emerald-600 text-white hover:bg-emerald-700" onClick={commitEdit} disabled={updateMutation.isPending}>
+                      {updateMutation.isPending ? "Saving…" : "Save"}
+                    </Button>
+                    <Button size="sm" variant="outline" className="flex-1 rounded-full" onClick={() => setEditingId(null)}>Cancel</Button>
+                  </div>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => startEdit(candidate.id)}
+                  className="mt-3 flex items-center gap-1.5 text-xs font-semibold text-muted-foreground hover:text-brand transition-colors"
+                >
+                  <Pencil className="h-3 w-3" />
+                  Edit details
+                </button>
+              )}
             </div>
           );
         })}
@@ -460,9 +621,10 @@ export default function ApprovalGatePage() {
               Reject All
             </Button>
             <Button
-              className="flex-1 rounded-full bg-emerald-600 text-white hover:bg-emerald-700 shadow-sm sm:flex-none"
-              disabled={effectiveSelectedIds.length === 0}
+              className="flex-1 rounded-full bg-emerald-600 text-white hover:bg-emerald-700 shadow-sm sm:flex-none disabled:opacity-50"
+              disabled={effectiveSelectedIds.length === 0 || overBudget}
               onClick={() => setConfirmOpen(true)}
+              title={overBudget ? "Selected total exceeds budget cap" : undefined}
             >
               <ShieldCheck className="mr-1.5 h-4 w-4" />
               Approve Selected

--- a/app/dashboard/runs/[id]/page.tsx
+++ b/app/dashboard/runs/[id]/page.tsx
@@ -32,6 +32,9 @@ import { useRun, useRunReport, useRunSteps, useInvalidateRunQueries } from "@/ho
 import { useTransactions } from "@/hooks/use-transaction-queries";
 import { useCandidates } from "@/hooks/use-candidate-queries";
 import { useRunEvents } from "@/hooks/use-run-events";
+import { useAssignApprover } from "@/hooks/use-candidate-mutations";
+import { useTeamMembers } from "@/hooks/use-team-queries";
+import { useAuth } from "@/context/auth-context";
 import type { PayoutCandidate } from "@/lib/mock-data";
 
 type BadgeStatus =
@@ -109,11 +112,11 @@ function summarizeRunStage(status: string): string {
     case "completed_with_errors":
       return "This run finished, but some recipients were held back or need follow-up.";
     case "completed":
-      return "This payout run finished successfully.";
+      return "This payout finished successfully.";
     case "failed":
       return "This run hit an error before completion.";
     default:
-      return "FlowPilot is preparing this payout run.";
+      return "FlowPilot is preparing this payout.";
   }
 }
 
@@ -541,9 +544,15 @@ const TABS = [
 export default function RunDetailPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
+  const { user } = useAuth();
+  const currentUserId = user?.id;
+  const currentUserRole = user?.memberships?.[0]?.role;
+
   // Default to the activity/progress tab — it's the mission-control hero view
   const [activeTab, setActiveTab] = useState("activity");
   const [selectedCandidate, setSelectedCandidate] = useState<PayoutCandidate | null>(null);
+  const [reassignOpen, setReassignOpen] = useState(false);
+  const [reassignUserId, setReassignUserId] = useState("");
 
   const { data: run, isLoading: loadingRun, isError: runError } = useRun(id);
   const { data: transactionsResponse, isLoading: loadingTransactions, isError: transactionsError } =
@@ -551,6 +560,20 @@ export default function RunDetailPage() {
   const { data: candidates = [], isLoading: loadingCandidates } = useCandidates(id);
   const { data: auditReport, isLoading: loadingReport, isError: reportError } =
     useRunReport(id, activeTab === "audit");
+  const { data: teamData } = useTeamMembers();
+  const assignApproverMutation = useAssignApprover(id, () => setReassignOpen(false));
+
+  // Only owners or approvers with approval capability
+  const approvalCapableMembers = (teamData?.members ?? []).filter(
+    (m) => (m.role === "owner" || m.role === "approver") && m.is_active && !m.is_pending,
+  );
+
+  // Whether the current user is the designated approver (or unassigned + capable)
+  const isAssignedApprover =
+    !run?.assignedToId || run.assignedToId === currentUserId;
+  const canApprove =
+    isAssignedApprover && (currentUserRole === "owner" || currentUserRole === "approver");
+  const isOwner = currentUserRole === "owner";
 
   // Real-time pipeline data (live for active runs, replay for completed/failed)
   const isLiveRun = LIVE_RUN_STATUSES.has(run?.status ?? "");
@@ -661,17 +684,87 @@ export default function RunDetailPage() {
 
       {/* Approval banner */}
       {run.status === "awaiting_approval" && (
-        <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 dark:border-amber-900 dark:bg-amber-950/30">
-          <div className="flex items-center gap-2 text-sm font-medium text-amber-800 dark:text-amber-300">
-            <AlertTriangle className="h-4 w-4 shrink-0" />
-            Agents completed pre-execution analysis. Approval is required before payouts can execute.
+        <div className="rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4 dark:border-amber-900 dark:bg-amber-950/30 space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-2 text-sm font-medium text-amber-800 dark:text-amber-300">
+              <AlertTriangle className="h-4 w-4 shrink-0" />
+              <span>
+                Analysis complete. Approval required before payouts execute.
+                {run.assignedTo && (
+                  <span className="ml-1 font-normal text-amber-700 dark:text-amber-400">
+                    Assigned to <span className="font-semibold">{run.assignedTo.name}</span>.
+                  </span>
+                )}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              {isOwner && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="rounded-full border-amber-300 text-amber-800 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-300"
+                  onClick={() => {
+                    setReassignUserId(run.assignedToId ?? "");
+                    setReassignOpen(true);
+                  }}
+                >
+                  Reassign
+                </Button>
+              )}
+              {canApprove ? (
+                <Button
+                  className="rounded-full bg-amber-500 px-6 text-white hover:bg-amber-600"
+                  onClick={() => router.push(`/dashboard/runs/${id}/approve`)}
+                >
+                  Review &amp; Approve
+                </Button>
+              ) : (
+                <span className="text-xs text-amber-700 dark:text-amber-400 font-medium">
+                  Waiting for {run.assignedTo?.name ?? "the assigned approver"} to review
+                </span>
+              )}
+            </div>
           </div>
-          <Button
-            className="rounded-full bg-amber-500 px-6 text-white hover:bg-amber-600"
-            onClick={() => router.push(`/dashboard/runs/${id}/approve`)}
-          >
-            Review &amp; Approve
-          </Button>
+        </div>
+      )}
+
+      {/* Reassign approver modal */}
+      {reassignOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
+          <div className="w-full max-w-sm rounded-2xl border border-border bg-card p-6 shadow-2xl">
+            <h3 className="text-lg font-black tracking-tight text-foreground">Reassign Approver</h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Choose who should review and approve this run.
+            </p>
+            <select
+              value={reassignUserId}
+              onChange={(e) => setReassignUserId(e.target.value)}
+              className="mt-4 h-10 w-full rounded-xl border border-border bg-background px-3 text-sm text-foreground outline-none focus:border-brand focus:ring-2 focus:ring-brand/20"
+            >
+              <option value="">Select approver…</option>
+              {approvalCapableMembers.map((m) => (
+                <option key={m.user_id} value={m.user_id}>
+                  {m.user?.display_name || m.user?.email || m.user_id} ({m.role})
+                </option>
+              ))}
+            </select>
+            <div className="mt-4 flex gap-2">
+              <Button
+                variant="outline"
+                className="flex-1 rounded-full"
+                onClick={() => setReassignOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                className="flex-1 rounded-full bg-brand text-white hover:opacity-90"
+                disabled={!reassignUserId || assignApproverMutation.isPending}
+                onClick={() => assignApproverMutation.mutate(reassignUserId)}
+              >
+                {assignApproverMutation.isPending ? "Saving…" : "Confirm"}
+              </Button>
+            </div>
+          </div>
         </div>
       )}
 
@@ -828,9 +921,9 @@ export default function RunDetailPage() {
 
       {/* Run info strip */}
       <div className="rounded-2xl border border-border bg-card px-6 py-5">
-        <p className="text-xs font-black uppercase tracking-wider text-muted-foreground mb-4">Run Details</p>
+        <p className="text-xs font-black uppercase tracking-wider text-muted-foreground mb-4">Payout Details</p>
         <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
-          <Detail label="Run ID" value={<span className="font-mono text-xs">{id}</span>} />
+          <Detail label="Payout ID" value={<span className="font-mono text-xs">{id}</span>} />
           <Detail label="Status" value={<StatusBadge status={status} label={statusLabel} />} />
           <Detail label="Total Volume" value={formatCurrency(totalCandidateAmount || summary.total_volume)} />
           <Detail label="Created" value={createdAtLabel} />

--- a/app/dashboard/runs/[id]/report/page.tsx
+++ b/app/dashboard/runs/[id]/report/page.tsx
@@ -79,10 +79,10 @@ export default function RunReportPage() {
           )}
 
           <Card className="rounded-xl border-slate-200 bg-white">
-            <CardHeader><CardTitle className="text-base">Run Summary</CardTitle></CardHeader>
+            <CardHeader><CardTitle className="text-base">Payout Summary</CardTitle></CardHeader>
             <CardContent className="grid gap-4 lg:grid-cols-2">
               <div className="grid grid-cols-2 gap-2 text-sm">
-                <KV label="Run ID" value={truncateRunId(id)} />
+                <KV label="Payout ID" value={truncateRunId(id)} />
                 <KV label="Status" value={<StatusBadge status="completed" />} />
               </div>
               {!!report.report?.risk_overview && (

--- a/app/dashboard/runs/new/page.tsx
+++ b/app/dashboard/runs/new/page.tsx
@@ -94,8 +94,8 @@ export default function NewRunPage() {
         <h2 className="text-xl font-bold text-foreground">Verification Required</h2>
         <p className="text-sm text-muted-foreground leading-relaxed">
           {kycStatus === "pending"
-            ? "Your business documents are under review. You'll be able to create payout runs once verification is complete (typically within 10 minutes)."
-            : "You need to complete business verification (KYC) before creating payout runs. This helps us ensure compliance and protect your account."}
+            ? "Your business documents are under review. You'll be able to create payouts once verification is complete (typically within 10 minutes)."
+            : "You need to complete business verification (KYC) before creating payouts. This helps us ensure compliance and protect your account."}
         </p>
         <Link
           href="/dashboard/kyc"
@@ -393,8 +393,8 @@ export default function NewRunPage() {
               <ArrowLeft className="h-4 w-4" />
             </button>
             <div>
-              <h1 className="text-xl font-black tracking-tight text-foreground md:text-2xl">New Run</h1>
-              <p className="hidden text-sm text-muted-foreground sm:block">Configure your treasury payout run</p>
+              <h1 className="text-xl font-black tracking-tight text-foreground md:text-2xl">New Payout</h1>
+              <p className="hidden text-sm text-muted-foreground sm:block">Configure your payout batch</p>
             </div>
           </div>
           {/* Mode pill toggle */}
@@ -528,7 +528,7 @@ export default function NewRunPage() {
             <ArrowLeft className="h-4 w-4" />
           </button>
           <div>
-            <h1 className="text-xl font-black tracking-tight text-foreground md:text-2xl">New Run</h1>
+            <h1 className="text-xl font-black tracking-tight text-foreground md:text-2xl">New Payout</h1>
             <p className="hidden text-sm text-muted-foreground sm:block">Configure your objective and payout recipients.</p>
           </div>
         </div>
@@ -767,7 +767,7 @@ export default function NewRunPage() {
             className="gap-2 rounded-full bg-brand px-8 text-white hover:opacity-90"
           >
             <Rocket className="h-4 w-4" />
-            Start Run
+            Start Payout
           </Button>
         </div>
       </div>

--- a/app/dashboard/runs/page.tsx
+++ b/app/dashboard/runs/page.tsx
@@ -5,8 +5,6 @@ import { useRouter, useSearchParams } from "next/navigation";
 import {
   Activity,
   ArrowRight,
-  BookmarkIcon,
-  CalendarClock,
   Copy,
   Download,
   FileSearch,
@@ -28,14 +26,13 @@ import { PageHeader } from "@/components/ui/page-header";
 import { useRuns } from "@/hooks/use-run-queries";
 import { RunFilterModal } from "@/components/dashboard/run/RunFilterModal";
 import { ExportRunsModal } from "@/components/dashboard/run/ExportRunsModal";
-import { RunTemplatesPicker } from "@/components/runs/RunTemplatesPicker";
 
 const LIVE_STATUSES = new Set(["planning", "reconciling", "scoring", "executing"]);
 
 const columns: TableColumn<RunRecord>[] = [
   {
     id: "id",
-    header: "Run ID",
+    header: "Payout ID",
     cell: (run) => (
       <button
         type="button"
@@ -111,7 +108,6 @@ export default function RunsPage() {
   const [query, setQuery] = useState("");
   const [filterOpen, setFilterOpen] = useState(false);
   const [exportOpen, setExportOpen] = useState(false);
-  const [templatesOpen, setTemplatesOpen] = useState(false);
   const [appliedFilters, setAppliedFilters] = useState<import("@/components/dashboard/run/RunFilterModal").RunFilters>({
     runId: "", status: "", minCandidates: "", fromDate: "", toDate: "",
   });
@@ -147,14 +143,14 @@ export default function RunsPage() {
       )}
 
       <PageHeader
-        title="Runs"
-        description="Monitor and manage all your automated treasury runs."
+        title="Payouts"
+        description="Monitor and manage all your payout batches."
       />
 
       {/* Metric cards */}
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
         <MetricCard
-          label="Total Runs"
+          label="Total Payouts"
           value={loadingRuns ? "…" : String(rows.length)}
           subtext="Active automation"
           icon={<Zap className="h-4 w-4" />}
@@ -182,7 +178,7 @@ export default function RunsPage() {
           accent="amber"
         />
         <MetricCard
-          label="Failed Runs"
+          label="Failed Payouts"
           value={
             loadingRuns
               ? "…"
@@ -230,16 +226,10 @@ export default function RunsPage() {
           <SearchInput
             value={query}
             onChange={setQuery}
-            placeholder="Search by objective or run ID..."
+            placeholder="Search by objective or payout ID..."
             className="w-full md:w-80"
           />
           <div className="flex w-full items-center gap-2 md:w-auto">
-            <ToolbarButton icon={<BookmarkIcon className="h-3.5 w-3.5" />} onClick={() => setTemplatesOpen(true)}>
-              Templates
-            </ToolbarButton>
-            <ToolbarButton icon={<CalendarClock className="h-3.5 w-3.5" />} onClick={() => router.push("/dashboard/runs/scheduled")}>
-              Scheduled
-            </ToolbarButton>
             <ToolbarButton icon={<SlidersHorizontal className="h-3.5 w-3.5" />} onClick={() => setFilterOpen(true)} badge={activeFilterCount || undefined}>
               Filter
             </ToolbarButton>
@@ -259,14 +249,6 @@ export default function RunsPage() {
             open={exportOpen}
             onClose={() => setExportOpen(false)}
             rows={rows}
-          />
-
-          <RunTemplatesPicker
-            open={templatesOpen}
-            onClose={() => setTemplatesOpen(false)}
-            onSelect={(objective) => {
-              router.push(`/dashboard/runs/new?objective=${encodeURIComponent(objective)}`);
-            }}
           />
         </div>
 
@@ -290,16 +272,16 @@ export default function RunsPage() {
             emptyState={
               <div className="space-y-3 flex items-center flex-col">
                 <p className="text-base font-black text-foreground">
-                  No runs found
+                  No payouts found
                 </p>
                 <p className="text-sm text-muted-foreground">
-                  Create your first run to start automated treasury execution.
+                  Create your first payout to get started.
                 </p>
                 <Button
                   className="mt-1 rounded-full bg-brand px-6 text-white hover:opacity-90"
                   onClick={openNewRun}
                 >
-                  Start Your First Run
+                  Start Your First Payout
                 </Button>
               </div>
             }

--- a/app/dashboard/runs/scheduled/page.tsx
+++ b/app/dashboard/runs/scheduled/page.tsx
@@ -136,15 +136,15 @@ export default function ScheduledRunsPage() {
   return (
     <div className="space-y-6">
       <PageHeader
-        title="Scheduled Runs"
-        description="Automated recurring payout runs."
+        title="Scheduled Payouts"
+        description="Automated recurring payouts."
       >
         <Button
           className="gap-2 rounded-full bg-brand px-5 text-sm text-white hover:opacity-90"
           onClick={() => setScheduleOpen(true)}
         >
           <CalendarClock className="h-4 w-4" />
-          New Scheduled Run
+          New Scheduled Payout
         </Button>
       </PageHeader>
 
@@ -230,7 +230,7 @@ export default function ScheduledRunsPage() {
                         onClick={() => setScheduleOpen(true)}
                       >
                         <CalendarClock className="h-4 w-4" />
-                        New Scheduled Run
+                        New Scheduled Payout
                       </Button>
                     </div>
                   </td>

--- a/app/dashboard/runs/templates/page.tsx
+++ b/app/dashboard/runs/templates/page.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Bookmark, Plus, Trash2, Zap } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/ui/page-header";
+import { useRunTemplates } from "@/hooks/use-run-templates";
+
+export default function TemplatesPage() {
+  const router = useRouter();
+  const { templates, saveTemplate, deleteTemplate } = useRunTemplates();
+
+  const [name, setName] = useState("");
+  const [objective, setObjective] = useState("");
+
+  const handleSave = () => {
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+    saveTemplate(trimmedName, objective.trim());
+    setName("");
+    setObjective("");
+    toast.success("Template saved.");
+  };
+
+  const handleDelete = (id: string, templateName: string) => {
+    deleteTemplate(id);
+    toast.success(`"${templateName}" deleted.`);
+  };
+
+  const handleUse = (obj: string) => {
+    router.push(`/dashboard/runs/new?objective=${encodeURIComponent(obj)}`);
+  };
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title="Templates"
+        description="Reusable payout objectives. Pick one to pre-fill a new payout."
+      />
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* ── Template list ──────────────────────────────────────────── */}
+        <div className="lg:col-span-2 space-y-3">
+          {templates.length === 0 ? (
+            <div className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-border bg-muted/10 py-20 text-center">
+              <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-muted text-muted-foreground">
+                <Bookmark className="h-7 w-7" />
+              </div>
+              <div>
+                <p className="text-base font-black text-foreground">No templates yet</p>
+                <p className="mt-1 text-sm text-muted-foreground max-w-xs">
+                  Save a payout objective as a template to reuse it in one click.
+                </p>
+              </div>
+            </div>
+          ) : (
+            templates.map((template) => (
+              <div
+                key={template.id}
+                className="flex items-start gap-4 rounded-2xl border border-border bg-card p-5 shadow-sm transition-all hover:border-brand/30 hover:shadow"
+              >
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-brand/10 text-brand">
+                  <Bookmark className="h-4 w-4" />
+                </div>
+
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-bold text-foreground">
+                    {template.name}
+                  </p>
+                  {template.objective ? (
+                    <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+                      {template.objective}
+                    </p>
+                  ) : (
+                    <p className="mt-0.5 text-xs italic text-muted-foreground/50">
+                      No objective saved
+                    </p>
+                  )}
+                  <p className="mt-2 text-[10px] text-muted-foreground/50">
+                    Saved{" "}
+                    {new Date(template.savedAt).toLocaleDateString("en-NG", {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    })}
+                  </p>
+                </div>
+
+                <div className="flex shrink-0 items-center gap-2">
+                  <Button
+                    size="sm"
+                    className="h-8 gap-1.5 rounded-full bg-brand px-4 text-xs font-bold text-white hover:opacity-90"
+                    onClick={() => handleUse(template.objective)}
+                  >
+                    <Zap className="h-3 w-3" />
+                    Use
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                    onClick={() => handleDelete(template.id, template.name)}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* ── Create new template ────────────────────────────────────── */}
+        <div className="rounded-2xl border border-border bg-card p-6 shadow-sm h-fit">
+          <div className="flex items-center gap-2 mb-5">
+            <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-brand/10 text-brand">
+              <Plus className="h-4 w-4" />
+            </div>
+            <p className="text-sm font-black text-foreground">New Template</p>
+          </div>
+
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                Name
+              </label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Monthly Payroll"
+                className="h-10 w-full rounded-xl border border-border bg-background px-3 text-sm outline-none transition-all focus:border-brand focus:ring-1 focus:ring-brand/10 placeholder:text-muted-foreground"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                Objective <span className="normal-case font-normal text-muted-foreground/60">(optional)</span>
+              </label>
+              <textarea
+                value={objective}
+                onChange={(e) => setObjective(e.target.value)}
+                placeholder="Pay all approved vendors from this month's invoices..."
+                rows={3}
+                className="w-full resize-none rounded-xl border border-border bg-background px-3 py-2.5 text-sm outline-none transition-all focus:border-brand focus:ring-1 focus:ring-brand/10 placeholder:text-muted-foreground"
+              />
+            </div>
+
+            <Button
+              className="w-full rounded-full bg-brand text-white hover:opacity-90 font-bold"
+              disabled={!name.trim()}
+              onClick={handleSave}
+            >
+              Save Template
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/stats/page.tsx
+++ b/app/dashboard/stats/page.tsx
@@ -108,12 +108,12 @@ export default function StatsPage() {
         <MetricCard
           label="Total Disbursed"
           value={statsLoading ? "…" : formatCurrency(stats?.total_volume_disbursed ?? 0)}
-          subtext="All-time across all runs"
+          subtext="All-time across all payouts"
           icon={<TrendingUp className="h-4 w-4" />}
           accent="brand"
         />
         <MetricCard
-          label="Total Runs"
+          label="Total Payouts"
           value={statsLoading ? "…" : String(totalRuns)}
           subtext={`${completedRuns} completed · ${failedRuns} failed`}
           icon={<Zap className="h-4 w-4" />}
@@ -122,14 +122,14 @@ export default function StatsPage() {
         <MetricCard
           label="Success Rate"
           value={statsLoading ? "…" : `${successRate}%`}
-          subtext="Runs completed successfully"
+          subtext="Payouts completed successfully"
           icon={<CheckCircle2 className="h-4 w-4" />}
           accent={successRate >= 80 ? "green" : successRate >= 50 ? "amber" : "default"}
         />
         <MetricCard
           label="Active Now"
           value={statsLoading ? "…" : String(stats?.active_runs ?? 0)}
-          subtext="Runs currently processing"
+          subtext="Payouts currently processing"
           icon={<Activity className="h-4 w-4" />}
           accent={stats?.active_runs ? "brand" : "default"}
         />

--- a/app/dashboard/transactions/page.tsx
+++ b/app/dashboard/transactions/page.tsx
@@ -82,8 +82,8 @@ export default function TransactionsPage() {
   const emptyMessage = activeFilterCount > 0
     ? "Try adjusting your filters."
     : isBankView
-      ? "Reconciled bank transactions will appear here after Transaction Search succeeds for a run."
-      : "Payout activity and reconciled bank transactions will appear here after runs complete.";
+      ? "Reconciled bank transactions will appear here after Transaction Search succeeds for a payout."
+      : "Payout activity and reconciled bank transactions will appear here after payouts complete.";
 
   return (
     <div className="space-y-6">

--- a/app/dashboard/wallet/page.tsx
+++ b/app/dashboard/wallet/page.tsx
@@ -324,7 +324,7 @@ export default function WalletPage() {
                   {/* Details */}
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-sm font-semibold text-foreground">
-                      {tx.description ?? (tx.type === "credit" ? "Wallet top-up" : "Run spend")}
+                      {tx.description ?? (tx.type === "credit" ? "Wallet top-up" : "Payout spend")}
                     </p>
                     <p className="mt-0.5 text-xs text-muted-foreground">
                       {formatDate(tx.created_at)}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -29,7 +29,7 @@ const STEP_META: StepMeta[] = [
   {
     title: "Tell us about your business.",
     subtitle: "This helps FlowPilot configure your reconciliation and risk settings.",
-    asideTitle: "You're 4 steps away from automated payout control.",
+    asideTitle: "Let's get your first payout run ready.",
     asideFeatures: [
       "AI reconciles thousands of transactions in seconds — not hours",
       "Risk scores catch suspicious payouts before they leave your account",

--- a/components/dashboard/AnalyticsSection.tsx
+++ b/components/dashboard/AnalyticsSection.tsx
@@ -338,10 +338,10 @@ export function AnalyticsSection() {
         <VolumeBarchart buckets={buckets} isLoading={txLoading} />
       </ChartCard>
 
-      {/* Run Outcomes */}
+      {/* Payout Outcomes */}
       <ChartCard
         icon={<PieChart className="h-3.5 w-3.5" />}
-        title="Run Outcomes"
+        title="Payout Outcomes"
         callout={String(runCounts.completed)}
         calloutLabel="completed"
       >

--- a/components/dashboard/TourGuide.tsx
+++ b/components/dashboard/TourGuide.tsx
@@ -22,8 +22,8 @@ const ALL_STEPS: TourStep[] = [
   },
   {
     tourId: "runs",
-    title: "Payout Runs",
-    description: "Chat with AI to create payout runs. Describe who to pay — FlowPilot builds the candidate list.",
+    title: "Payouts",
+    description: "Chat with AI to create payouts. Describe who to pay — FlowPilot builds the candidate list.",
   },
   {
     tourId: "approvals",
@@ -50,7 +50,7 @@ const ALL_STEPS: TourStep[] = [
   },
   {
     title: "You're all set! 🎉",
-    description: "Head to Runs and create your first payout run. Retake this tour anytime from the navbar.",
+    description: "Head to Payouts and create your first payout. Retake this tour anytime from the navbar.",
   },
 ];
 

--- a/components/dashboard/audit/ExportAuditModal.tsx
+++ b/components/dashboard/audit/ExportAuditModal.tsx
@@ -27,7 +27,7 @@ function applyDateFilter(entries: AuditEntry[], fromDate: string, toDate: string
 }
 
 function downloadCSV(entries: AuditEntry[]) {
-  const header = "ID,Agent,Action,Run ID,Timestamp";
+  const header = "ID,Agent,Action,Payout ID,Timestamp";
   const lines = entries.map((e) =>
     [
       e.id,
@@ -65,7 +65,7 @@ async function buildPDFDoc(entries: AuditEntry[]) {
 
   autoTable(doc, {
     startY: 32,
-    head: [["Agent", "Action", "Run ID", "Timestamp"]],
+    head: [["Agent", "Action", "Payout ID", "Timestamp"]],
     body: entries.map((e) => [
       e.agent_type,
       e.action,

--- a/components/dashboard/navbar.tsx
+++ b/components/dashboard/navbar.tsx
@@ -40,7 +40,7 @@ export function Navbar() {
             className="h-10 rounded-full bg-brand px-4 md:px-6 font-bold text-white transition-all shadow-sm hover:opacity-90"
           >
             <Plus className="h-4 w-4 stroke-3 md:mr-1.5" />
-            <span className="hidden md:inline">New Run</span>
+            <span className="hidden md:inline">New Payout</span>
           </Button>
         )}
         {isTeamPage && (

--- a/components/dashboard/run/ExportRunsModal.tsx
+++ b/components/dashboard/run/ExportRunsModal.tsx
@@ -40,7 +40,7 @@ function applyFilters(rows: RunRecord[], f: ExportFilters): RunRecord[] {
 }
 
 function downloadCSV(rows: RunRecord[]) {
-  const header = "Run ID,Objective,Status,Candidates,Started";
+  const header = "Payout ID,Objective,Status,Candidates,Started";
   const lines = rows.map((r) =>
     [r.id, `"${r.objective.replace(/"/g, '""')}"`, r.status, r.candidates, r.startedAt].join(",")
   );
@@ -70,13 +70,13 @@ export function ExportRunsModal({ open, onClose, rows }: ExportRunsModalProps) {
     <Modal
       open={open}
       onClose={onClose}
-      title="Export Runs"
-      description="Filter which runs to include before downloading."
+      title="Export Payouts"
+      description="Filter which payouts to include before downloading."
       maxWidth="max-w-md"
       footer={
         <>
           <span className="text-xs text-muted-foreground">
-            {preview.length} of {rows.length} run{rows.length !== 1 ? "s" : ""} selected
+            {preview.length} of {rows.length} payout{rows.length !== 1 ? "s" : ""} selected
           </span>
           <Button
             className="gap-2 rounded-full bg-brand px-6 text-white hover:opacity-90"
@@ -90,7 +90,7 @@ export function ExportRunsModal({ open, onClose, rows }: ExportRunsModalProps) {
       }
     >
       <div className="space-y-5">
-        <Field label="Run ID contains">
+        <Field label="Payout ID contains">
           <TextInput value={draft.runId} onChange={(v) => set("runId", v)} placeholder="e.g. a3f9b2c1" />
         </Field>
 

--- a/components/dashboard/run/RunFilterModal.tsx
+++ b/components/dashboard/run/RunFilterModal.tsx
@@ -51,8 +51,8 @@ export function RunFilterModal({ open, onClose, onApply, current }: RunFilterMod
     <Modal
       open={open}
       onClose={onClose}
-      title="Filter Runs"
-      description="Narrow down runs by any combination of fields."
+      title="Filter Payouts"
+      description="Narrow down payouts by any combination of fields."
       maxWidth="max-w-md"
       footer={
         <>
@@ -66,7 +66,7 @@ export function RunFilterModal({ open, onClose, onApply, current }: RunFilterMod
       }
     >
       <div className="space-y-5">
-        <Field label="Run ID">
+        <Field label="Payout ID">
           <TextInput
             value={draft.runId}
             onChange={(v) => set("runId", v)}

--- a/components/dashboard/sidebar.tsx
+++ b/components/dashboard/sidebar.tsx
@@ -22,6 +22,8 @@ import {
   BarChart2,
   MessageSquare,
   Wallet,
+  CalendarClock,
+  Bookmark,
 } from "lucide-react";
 import { Logo } from "@/components/brand/Logo";
 import { cn } from "@/lib/utils";
@@ -70,10 +72,17 @@ type NavGroup = {
 
 const navGroups: NavGroup[] = [
   {
+    label: "Payouts",
+    items: [
+      { label: "All Payouts", href: "/dashboard/runs", icon: LayoutDashboard },
+      { label: "Scheduled", href: "/dashboard/runs/scheduled", icon: CalendarClock },
+      { label: "Templates", href: "/dashboard/runs/templates", icon: Bookmark },
+    ],
+  },
+  {
     label: "Operations",
     items: [
       { label: "Overview", href: "/dashboard", icon: Home },
-      { label: "Runs", href: "/dashboard/runs", icon: LayoutDashboard },
       { label: "Conversations", href: "/dashboard/conversations", icon: MessageSquare },
       { label: "Approvals", href: "/dashboard/approvals", icon: ClipboardCheck, roles: ["approver", "owner"] },
       { label: "Transactions", href: "/dashboard/transactions", icon: ArrowLeftRight },

--- a/components/dashboard/transaction/TransactionFilterModal.tsx
+++ b/components/dashboard/transaction/TransactionFilterModal.tsx
@@ -70,7 +70,7 @@ export function TransactionFilterModal({ open, onClose, onApply, current }: Tran
       }
     >
       <div className="space-y-5">
-        <Field label="Run ID">
+        <Field label="Payout ID">
           <TextInput
             value={draft.runId}
             onChange={(v) => set("runId", v)}

--- a/components/landing/landing-features.tsx
+++ b/components/landing/landing-features.tsx
@@ -5,43 +5,43 @@ import { Bolt, BrainCircuit, FileCheck2, Hand, ShieldCheck, Cpu } from "lucide-r
 const features = [
   {
     icon: BrainCircuit,
-    title: "Self-Healing Ledger",
-    text: "Agents don't just find mismatches; they suggest resolutions for duplicate entries and orphan references in real-time.",
+    title: "Catches Payment Errors Automatically",
+    text: "Detects duplicate payments, mismatched references, and orphaned transactions before they cause problems — no manual reconciliation needed.",
     accent: "#0A84FF",
     tone: "bg-[#EAF2FF] text-[#0A84FF]",
   },
   {
     icon: ShieldCheck,
-    title: "Anti-Fraud Engine",
-    text: "Automatic cross-referencing of account numbers against Interswitch's KYC database before any funds are staged.",
+    title: "Verifies Every Recipient Before Money Moves",
+    text: "Every account number is cross-checked against Interswitch's KYC database before a single Naira is staged for payout.",
     accent: "#0D9D6D",
     tone: "bg-[#E8FBF2] text-[#0D9D6D]",
   },
   {
     icon: Bolt,
-    title: "Liquidity Guard",
-    text: "Real-time stress testing ensures that proposed payout batches never compromise your operating capital.",
+    title: "Checks You Can Afford It First",
+    text: "FlowPilot stress-tests your balance against the payout batch — so you never accidentally overdraw your operating account.",
     accent: "#D98700",
     tone: "bg-[#FFF5E6] text-[#D98700]",
   },
   {
     icon: Hand,
-    title: "Human-in-the-Loop",
-    text: "Deterministic safety rails. No agent can execute a transaction without a cryptographically signed human approval.",
+    title: "Nothing Moves Without Your Approval",
+    text: "Every payout run pauses for your sign-off. No AI executes transactions on its own — you stay in control, always.",
     accent: "#C0445E",
     tone: "bg-[#FFF0F2] text-[#C0445E]",
   },
   {
     icon: Cpu,
-    title: "Direct Protocol Access",
-    text: "Native integration with Interswitch search, lookup, and payout APIs for sub-second execution.",
+    title: "Powered by Interswitch — Bank-Grade Speed",
+    text: "Native connection to Interswitch's search, lookup, and payout APIs. Payments execute in real time, not overnight batches.",
     accent: "#1B2A44",
     tone: "bg-[#EEF0F5] text-[#1B2A44]",
   },
   {
     icon: FileCheck2,
-    title: "Automated Compliance",
-    text: "Every run generates a pre-formatted audit pack, including API timestamps and agent reasoning, ready for review.",
+    title: "Automatic Audit Report — Every Time",
+    text: "Every completed run generates a compliance-ready report with timestamps, agent reasoning, and full transaction history.",
     accent: "#0D7EA6",
     tone: "bg-[#EBF9FF] text-[#0D7EA6]",
   },
@@ -59,12 +59,12 @@ export function LandingFeatures() {
               Capabilities
             </span>
             <h2 className="mt-4 text-4xl font-extrabold tracking-tight text-[#0F0F0F] md:text-5xl">
-              Everything an SME <br className="hidden md:block" />
-              treasury team needs.
+              Everything your finance team <br className="hidden md:block" />
+              needs to pay with confidence.
             </h2>
           </div>
           <p className="max-w-xs text-sm font-medium leading-relaxed text-[#6B6B6B]">
-            Built as an execution surface for complex payments, not a passive chatbot.
+            Not a chatbot — an active payment system that verifies, checks, and executes. With you in control at every step.
           </p>
         </div>
 

--- a/components/landing/landing-footer.tsx
+++ b/components/landing/landing-footer.tsx
@@ -14,8 +14,8 @@ export function LandingFooter() {
               FLOWPILOT<span className="text-[#e86727]">.</span>
             </Link>
             <p className="mt-4 max-w-sm text-sm leading-relaxed text-white/40">
-              The execution layer for modern SME treasury. Supervised AI that reconciles,
-              scores risk, and executes payouts with total traceability.
+              Smart bulk payment automation for African SMEs. Verify recipients, catch fraud,
+              approve payouts, and stay compliant — all in one place.
             </p>
             {/* Live System Status */}
             <div className="mt-8 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5">

--- a/components/landing/landing-hero.tsx
+++ b/components/landing/landing-hero.tsx
@@ -19,14 +19,14 @@ export function LandingHero() {
         </div> */}
 
         <h1 className="mx-auto mt-7 max-w-3xl text-center text-5xl font-extrabold leading-[1.06] tracking-tight text-[#0F0F0F] md:text-7xl">
-          Treasury execution,{" "}
-          <span className="text-[#e86727]">without the drag.</span>
+          Pay your team and vendors in bulk {" "}
+          <span className="text-[#e86727]">safely, in minutes.</span>
         </h1>
 
         <p className="mx-auto mt-6 max-w-120 text-center text-[12px] leading-relaxed text-[#6B6B6B] md:text-[16px]">
-          FlowPilot turns operator goals into supervised runs. Agents reconcile,
-          score risk, verify recipients, and execute approved payouts with
-          full traceability.
+          FlowPilot automates your business payouts: verifies every recipient,
+          catches duplicates and fraud, and waits for your approval before a
+          single Naira moves.
         </p>
 
         <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row sm:gap-3">
@@ -34,7 +34,7 @@ export function LandingHero() {
             href="/signup"
             className="group inline-flex h-12 w-full items-center justify-center gap-2 rounded-full bg-[#0F0F0F] px-8 text-sm font-bold text-white transition-all hover:bg-[#2A2A2A] hover:shadow-xl hover:shadow-black/10 active:scale-[0.98] sm:w-auto"
           >
-            Start Free
+            Start Your First Payout
             <ArrowRight className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
           </Link>
 
@@ -46,13 +46,13 @@ export function LandingHero() {
           </Link>
         </div>
 
-        {/* <div className="mt-8 flex flex-wrap items-center justify-center gap-6 text-xs font-medium text-[#9A9A9A]">
-          <span>Built for SMEs</span>
+        <div className="mt-8 flex flex-wrap items-center justify-center gap-6 text-xs font-medium text-[#9A9A9A]">
+          <span>Built for African SMEs</span>
           <span className="h-1 w-1 rounded-full bg-[#D9D4C8]" />
           <span>Human-approved payouts</span>
           <span className="h-1 w-1 rounded-full bg-[#D9D4C8]" />
           <span>Audit ready by default</span>
-        </div> */}
+        </div>
 
         <PipelineSection/>
       </div>

--- a/components/landing/landing-how-it-works.tsx
+++ b/components/landing/landing-how-it-works.tsx
@@ -5,23 +5,23 @@ import { PlaneLine } from "@/public/svg/PlaneLine";
 
 const steps = [
   {
-    title: "Configure Intent",
-    text: "Set natural language parameters for the run—like budget caps, date ranges for reconciliation, and specific risk tolerance levels.",
+    title: "Tell FlowPilot What to Do",
+    text: "Describe the run in plain English — \"pay all approved vendors from this month.\" Set budget caps and date ranges as needed.",
     color: "#e86727",
   },
   {
-    title: "Multi-Agent Sync",
-    text: "Planner orchestrates the cycle: ReconciliationAgent pulls Interswitch logs, while RiskAgent cross-references lookup data.",
+    title: "AI Checks Everything",
+    text: "FlowPilot verifies every account is real, scans for duplicates, cross-checks your balance, and flags anything that looks off.",
     color: "#0A84FF",
   },
   {
-    title: "Human Checkpoint",
-    text: "The system pauses for your review. Inspect liquidity forecasts and recipient verification results before a single Naira moves.",
+    title: "You Review and Approve",
+    text: "See exactly who gets paid, how much, and why anything was flagged. Nothing moves until you sign off.",
     color: "#0D9D6D",
   },
   {
-    title: "Atomic Execution",
-    text: "Approved payouts are fired through Interswitch Payout APIs with real-time status tracking and an immutable audit report.",
+    title: "Payments Go Out Instantly",
+    text: "Approved payouts fire through Interswitch in real time. A full compliance report is generated automatically when done.",
     color: "#6B4EFF",
   },
 ];
@@ -42,16 +42,15 @@ export function LandingHowItWorks() {
         <div className="mb-12 md:mb-20 flex flex-col items-start justify-between gap-6 lg:flex-row lg:items-end">
           <div className="max-w-2xl">
             <span className="text-[11px] font-bold uppercase tracking-[0.2em] text-[#e86727]">
-              Runtime Model
+              How It Works
             </span>
             <h2 className="mt-4 text-3xl font-extrabold tracking-tight text-[#0F0F0F] sm:text-4xl md:text-5xl">
-              A plan that flows,{" "}
-              <span className="text-[#e86727]">supervised.</span>
+              Picture this: it&apos;s Friday,{" "}
+              <span className="text-[#e86727]">80 vendors to pay by end of day.</span>
             </h2>
           </div>
           <p className="max-w-xs text-sm font-medium leading-relaxed text-[#6B6B6B]">
-            Your instructions pass through a rigorous multi-agent graph with
-            human checkpoints.
+            Here&apos;s how FlowPilot handles it — from your instruction to bank execution.
           </p>
         </div>
 

--- a/components/landing/landing-integrations.tsx
+++ b/components/landing/landing-integrations.tsx
@@ -3,10 +3,10 @@ export function LandingIntegrations() {
     <section className="bg-[#FAF8F4] py-20 border-t border-[#E8E4DC]">
       <div className="mx-auto max-w-7xl px-6 md:px-10 text-center">
         <span className="text-[10px] font-black uppercase tracking-[0.3em] text-[#9A9A9A]">
-          Direct Protocol Access
+          Bank-Grade Infrastructure
         </span>
         <h3 className="mt-4 text-2xl font-bold text-[#0F0F0F] md:text-3xl">
-          Connected to the Interswitch Ecosystem
+          Built on the Interswitch Network
         </h3>
         
         {/* Grid: 2 columns on mobile, auto-flow on desktop */}

--- a/components/settings/ApiKeysSection.tsx
+++ b/components/settings/ApiKeysSection.tsx
@@ -15,8 +15,8 @@ import { useApiKeys, useCreateApiKey, useRevokeApiKey } from "@/hooks/use-api-ke
 import type { ApiKey } from "@/lib/api-developer";
 
 const SCOPES = [
-  { value: "runs:read", label: "Read runs" },
-  { value: "runs:write", label: "Create & manage runs" },
+  { value: "runs:read", label: "Read payouts" },
+  { value: "runs:write", label: "Create & manage payouts" },
   { value: "approvals:read", label: "Read approvals" },
   { value: "approvals:write", label: "Submit approvals" },
   { value: "transactions:read", label: "Read transactions" },

--- a/components/settings/ApiPlaygroundSection.tsx
+++ b/components/settings/ApiPlaygroundSection.tsx
@@ -30,7 +30,7 @@ const ENDPOINTS: EndpointDef[] = [
     id: "list_runs",
     method: "GET",
     path: "/runs",
-    description: "List payout runs for your organisation, newest first.",
+    description: "List payouts for your organisation, newest first.",
     scope: "runs:read",
     pathParams: [],
     queryParams: [

--- a/components/settings/WebhooksSection.tsx
+++ b/components/settings/WebhooksSection.tsx
@@ -28,8 +28,8 @@ import {
 import type { Webhook as WebhookType } from "@/lib/api-developer";
 
 const WEBHOOK_EVENTS = [
-  { value: "run.completed", label: "Run Completed" },
-  { value: "run.failed", label: "Run Failed" },
+  { value: "run.completed", label: "Payout Completed" },
+  { value: "run.failed", label: "Payout Failed" },
   { value: "payout.succeeded", label: "Payout Succeeded" },
   { value: "payout.failed", label: "Payout Failed" },
   { value: "approval.requested", label: "Approval Requested" },

--- a/components/ui/landing/PassportCard.tsx
+++ b/components/ui/landing/PassportCard.tsx
@@ -1,41 +1,41 @@
 "use client";
 
 const pipeline = [
-  { 
-    step: "01", 
-    title: "Reconciliation", 
-    rotation: "-rotate-6", 
-    zIndex: "z-10", 
+  {
+    step: "01",
+    title: "Reconciliation",
+    rotation: "-rotate-6",
+    zIndex: "z-10",
     status: "Matching Active",
-    label: "Ingestion Engine",
-    description: "Normalizing multi-channel data streams to resolve unmatched transaction references."
+    label: "Error Detection",
+    description: "Checks every transaction for duplicates, mismatches, and orphaned entries — in seconds."
   },
-  { 
-    step: "02", 
-    title: "Risk Scoring", 
-    rotation: "rotate-2", 
-    zIndex: "z-20", 
+  {
+    step: "02",
+    title: "Risk Scoring",
+    rotation: "rotate-2",
+    zIndex: "z-20",
     status: "Scoring Layer",
-    label: "Security Kernel",
-    description: "Analyzing payout candidates against historical patterns and liquidity stress factors."
+    label: "Fraud Check",
+    description: "Analyses each payout against fraud signals, account history, and your live balance."
   },
-  { 
-    step: "03", 
-    title: "Approval Gate", 
-    rotation: "-rotate-3", 
-    zIndex: "z-30", 
-    status: "Awaiting Ops",
-    label: "Verification Node",
-    description: "Human-in-the-loop review for high-variance candidates before final signature."
+  {
+    step: "03",
+    title: "Approval Gate",
+    rotation: "-rotate-3",
+    zIndex: "z-30",
+    status: "Awaiting You",
+    label: "You're in Control",
+    description: "Pauses for your review. Inspect the results and approve before any money moves."
   },
-  { 
-    step: "04", 
-    title: "Execution", 
-    rotation: "rotate-6", 
-    zIndex: "z-40", 
-    status: "Ready to Push",
-    label: "Disbursement Hub",
-    description: "Finalizing real-time instructions to Interswitch APIs for instant settlement."
+  {
+    step: "04",
+    title: "Execution",
+    rotation: "rotate-6",
+    zIndex: "z-40",
+    status: "Ready to Send",
+    label: "Payment Hub",
+    description: "Sends approved payments through Interswitch instantly, with live status and a full audit trail."
   },
 ];
 

--- a/hooks/use-candidate-mutations.ts
+++ b/hooks/use-candidate-mutations.ts
@@ -2,7 +2,13 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { approveCandidates, rejectCandidates } from "@/lib/api-client";
+import {
+  approveCandidates,
+  assignApprover,
+  rejectCandidates,
+  updateCandidate,
+} from "@/lib/api-client";
+import type { UpdateCandidatePayload, AssignApproverResponse } from "@/lib/api-client";
 import { ApiError } from "@/lib/api-types";
 
 export function useApproveCandidates(runId: string, onSuccess?: () => void) {
@@ -18,6 +24,48 @@ export function useApproveCandidates(runId: string, onSuccess?: () => void) {
     onError: (err) => {
       const message =
         err instanceof ApiError ? err.message : "Approval failed. Please try again.";
+      toast.error(message);
+    },
+  });
+}
+
+export function useUpdateCandidate(runId: string, onSuccess?: () => void) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      candidateId,
+      payload,
+    }: {
+      candidateId: string;
+      payload: UpdateCandidatePayload;
+    }) => updateCandidate(runId, candidateId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["run-candidates", runId] });
+      toast.success("Candidate updated.");
+      onSuccess?.();
+    },
+    onError: (err) => {
+      const message =
+        err instanceof ApiError ? err.message : "Failed to update candidate. Please try again.";
+      toast.error(message);
+    },
+  });
+}
+
+export function useAssignApprover(runId: string, onSuccess?: (data: AssignApproverResponse) => void) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: string) => assignApprover(runId, userId),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["run", runId] });
+      toast.success(`Approver assigned to ${data.assigned_to_name}.`);
+      onSuccess?.(data);
+    },
+    onError: (err) => {
+      const message =
+        err instanceof ApiError ? err.message : "Failed to assign approver. Please try again.";
       toast.error(message);
     },
   });

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -147,6 +147,36 @@ export function listCandidates(runId: string, approvalStatus?: string): Promise<
     .then((r) => r.data);
 }
 
+export interface UpdateCandidatePayload {
+  amount?: number;
+  beneficiary_name?: string;
+  account_number?: string;
+  institution_code?: string;
+}
+
+export function updateCandidate(
+  runId: string,
+  candidateId: string,
+  payload: UpdateCandidatePayload,
+): Promise<import("./api-types").Candidate> {
+  return apiClient
+    .patch<import("./api-types").Candidate>(`/runs/${runId}/candidates/${candidateId}`, payload)
+    .then((r) => r.data);
+}
+
+export interface AssignApproverResponse {
+  run_id: string;
+  assigned_to_id: string;
+  assigned_to_name: string;
+  assigned_to_email: string;
+}
+
+export function assignApprover(runId: string, userId: string): Promise<AssignApproverResponse> {
+  return apiClient
+    .patch<AssignApproverResponse>(`/runs/${runId}/assign-approver`, { user_id: userId })
+    .then((r) => r.data);
+}
+
 // ── 5. Approvals ─────────────────────────────────────────────────────────────
 
 export function approveCandidates(runId: string, candidateIds: string[]): Promise<ApproveResponse> {

--- a/lib/api-types.ts
+++ b/lib/api-types.ts
@@ -170,12 +170,21 @@ export interface PlanStep {
   status: string;
 }
 
+export interface AssignedTo {
+  id: string;
+  name: string;
+  email: string;
+}
+
 export interface ApiRunRecord {
   run_id: string;
   objective: string;
   status: ApiRunStatus;
   created_at: string;
   risk_tolerance?: number | null;
+  budget_cap?: number | null;
+  assigned_to_id?: string | null;
+  assigned_to?: AssignedTo | null;
   current_step?: string | null;
   candidate_count?: number;
   // Detail-only fields (absent in list response)

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -38,6 +38,9 @@ export type RunRecord = {
   startedAt: string;
   startedAtLabel: string;
   error?: string | null;
+  budgetCap?: number | null;
+  assignedToId?: string | null;
+  assignedTo?: { id: string; name: string; email: string } | null;
 };
 
 export const institutions = [

--- a/utils/useHelper.ts
+++ b/utils/useHelper.ts
@@ -88,6 +88,9 @@ export function adaptRun(r: ApiRunRecord): RunRecord {
     startedRelative,
     startedAt: r.created_at,
     startedAtLabel,
+    budgetCap: r.budget_cap ?? null,
+    assignedToId: r.assigned_to_id ?? null,
+    assignedTo: r.assigned_to ?? null,
   };
 }
 


### PR DESCRIPTION
…lates page, approver assignment, candidate editing, deferred wallet debit

- Rename all user-facing "run/runs" labels to "payout/payouts" across dashboard, landing, and settings
- Add Payouts sidebar group (All Payouts, Scheduled, Templates) replacing toolbar shortcuts
- New standalone Templates page at /dashboard/runs/templates
- Approver assignment: only the assigned approver (or an owner override) sees the Approve button
- Candidate editing: inline edit of amount/name/account before approval with budget cap guard
- Wallet debit moved to post-approval execution; debit only the actual approved total
- Add AssignApprover and UpdateCandidate mutations + API client methods
- Update RunRecord, ApiRunRecord, and adaptRun() to carry budgetCap, assignedToId, assignedTo